### PR TITLE
Locust Worker 스케일링을 위한 유니크 컨테이너 이름 제거

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,8 +33,9 @@ services:
     command: -f /mnt/locust/locustfile.py --master -H http://host.docker.internal:8080
 
   locust-worker:
-    container_name: pj3-coupon-locust-worker
     image: locustio/locust
+    depends_on:
+      - locust-master
     volumes:
       - ./locust/:/mnt/locust
     command: -f /mnt/locust/locustfile.py --worker --master-host locust-master


### PR DESCRIPTION
- docker-compose -p pj3-coupon up -d --scale locust-worker=3
