### PR TITLE
Consumer 분리 완료

### DIFF
--- a/coupon-api/src/main/java/cwchoiit/couponapi/controller/CouponIssueController.java
+++ b/coupon-api/src/main/java/cwchoiit/couponapi/controller/CouponIssueController.java
@@ -1,7 +1,7 @@
 package cwchoiit.couponapi.controller;
 
 import cwchoiit.couponapi.controller.response.ApiResponse;
-import cwchoiit.couponapi.service.CouponIssueRequestService;
+import cwchoiit.couponapi.service.CouponApiIssueRequestService;
 import cwchoiit.couponapi.service.request.CouponIssueRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/coupons/api")
 public class CouponIssueController {
 
-    private final CouponIssueRequestService couponIssueRequestService;
+    private final CouponApiIssueRequestService couponIssueRequestService;
 
     @PostMapping("/v1/issue")
     public ResponseEntity<ApiResponse<Void>> issueCoupon(@RequestBody CouponIssueRequest request) {

--- a/coupon-api/src/main/java/cwchoiit/couponapi/service/CouponApiIssueRequestService.java
+++ b/coupon-api/src/main/java/cwchoiit/couponapi/service/CouponApiIssueRequestService.java
@@ -2,7 +2,7 @@ package cwchoiit.couponapi.service;
 
 import cwchoiit.couponapi.service.request.CouponIssueRequest;
 import cwchoiit.couponcore.component.DistributeLockExecutor;
-import cwchoiit.couponcore.service.CouponIssueService;
+import cwchoiit.couponcore.service.CouponIssueRequestService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -10,8 +10,8 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class CouponIssueRequestService {
-    private final CouponIssueService couponIssueService;
+public class CouponApiIssueRequestService {
+    private final CouponIssueRequestService couponIssueRequestService;
     private final DistributeLockExecutor distributeLockExecutor;
 
     public void requestIssue(CouponIssueRequest request) {
@@ -19,7 +19,7 @@ public class CouponIssueRequestService {
                 "lock_%s".formatted(request.couponId()),
                 10000,
                 10000,
-                () -> couponIssueService.issue(request.couponId(), request.userId())
+                () -> couponIssueRequestService.request(request.couponId(), request.userId())
         );
 
         log.info("[requestIssue] Coupon {} issued to user {}", request.couponId(), request.userId());

--- a/coupon-consumer/src/main/java/cwchoiit/couponconsumer/CouponConsumerApplication.java
+++ b/coupon-consumer/src/main/java/cwchoiit/couponconsumer/CouponConsumerApplication.java
@@ -4,9 +4,11 @@ import cwchoiit.couponcore.CouponCoreConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
-@Import(CouponCoreConfiguration.class)
+@EnableScheduling
 @SpringBootApplication
+@Import(CouponCoreConfiguration.class)
 public class CouponConsumerApplication {
 
     public static void main(String[] args) {

--- a/coupon-consumer/src/main/java/cwchoiit/couponconsumer/component/CouponIssueListener.java
+++ b/coupon-consumer/src/main/java/cwchoiit/couponconsumer/component/CouponIssueListener.java
@@ -1,0 +1,43 @@
+package cwchoiit.couponconsumer.component;
+
+import cwchoiit.couponcore.service.CouponIssueRequestService;
+import cwchoiit.couponcore.service.CouponIssueService;
+import cwchoiit.couponcore.service.CouponService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CouponIssueListener {
+
+    private final CouponIssueRequestService couponIssueRequestService;
+    private final CouponService couponService;
+    private final CouponIssueService couponIssueService;
+
+    @Scheduled(fixedDelay = 10000L, initialDelay = 10000L, timeUnit = TimeUnit.MILLISECONDS)
+    public void issue() {
+        log.debug("[issue] Schedule issue ...");
+        couponService.findAll()
+                .forEach(coupon -> {
+                    while (existCouponIssued(coupon.getCouponId())) {
+                        log.debug("[issue] Coupon {} is issuing", coupon.getCouponId());
+                        Long userId = findUserIdByIssuedCoupon(coupon.getCouponId());
+                        couponIssueService.issue(coupon.getCouponId(), userId);
+                        log.debug("[issue] Coupon {} issued to user {}", coupon.getCouponId(), userId);
+                    }
+                });
+    }
+
+    private boolean existCouponIssued(Long couponId) {
+        return couponIssueRequestService.issuedQueueSize(couponId) > 0;
+    }
+
+    private Long findUserIdByIssuedCoupon(Long couponId) {
+        return couponIssueRequestService.findUserIdByIssuedCoupon(couponId);
+    }
+}

--- a/coupon-consumer/src/main/resources/application-consumer.yaml
+++ b/coupon-consumer/src/main/resources/application-consumer.yaml
@@ -1,6 +1,13 @@
 spring:
+  config:
+    activate:
+      on-profile: local
   application:
     name: coupon-consumer
 
 server:
   port: 8081
+
+logging:
+  level:
+    cwchoiit.couponconsumer: debug

--- a/coupon-core/src/main/java/cwchoiit/couponcore/service/CouponIssueRequestService.java
+++ b/coupon-core/src/main/java/cwchoiit/couponcore/service/CouponIssueRequestService.java
@@ -1,0 +1,159 @@
+package cwchoiit.couponcore.service;
+
+import cwchoiit.couponcore.component.DistributeLockExecutor;
+import cwchoiit.couponcore.exception.CouponCoreErrorCode;
+import cwchoiit.couponcore.model.Coupon;
+import cwchoiit.couponcore.service.response.CouponReadResponse;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+
+import static cwchoiit.couponcore.exception.CouponCoreErrorCode.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CouponIssueRequestService {
+    private static final String QUEUE_KEY = "issued:queue:couponId";
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final CouponService couponService;
+    private final DistributeLockExecutor distributeLockExecutor;
+
+    public void request(Long couponId, Long userId) {
+        CouponReadResponse couponReadResponse = couponService.findCoupon(couponId);
+        Coupon coupon = Coupon.builder()
+                .couponId(couponReadResponse.getCouponId())
+                .title(couponReadResponse.getTitle())
+                .couponType(couponReadResponse.getCouponType())
+                .totalQuantity(couponReadResponse.getTotalQuantity())
+                .issuedQuantity(couponReadResponse.getIssuedQuantity())
+                .dateIssueStart(couponReadResponse.getDateIssueStart())
+                .dateIssueEnd(couponReadResponse.getDateIssueEnd())
+                .build();
+
+        if (!coupon.availableIssueDate()) {
+            throw INVALID_COUPON_ISSUE_DATE.build(
+                    LocalDateTime.now(),
+                    coupon.getDateIssueStart(),
+                    coupon.getDateIssueEnd()
+            );
+        }
+
+        distributeLockExecutor.execute(
+                "lock_%s".formatted(couponId),
+                3000,
+                3000,
+                () -> {
+                    if (!availableTotalIssueQuantity(couponId, coupon.getTotalQuantity())) {
+                        throw INVALID_COUPON_ISSUE_QUANTITY.build(
+                                redisTemplate.opsForSet().size(generateKey(couponId)),
+                                coupon.getTotalQuantity()
+                        );
+                    }
+
+                    if (!availableUserIssueQuantity(couponId, userId)) {
+                        throw DUPLICATED_COUPON_ISSUED.build(couponId, userId);
+                    }
+
+                    redisTemplate.opsForSet()
+                            .add(generateKey(couponId), String.valueOf(userId));
+                    redisTemplate.opsForList()
+                            .rightPush(generateQueueKey(couponId), String.valueOf(userId));
+                }
+        );
+    }
+
+    public Long issuedQueueSize(Long couponId) {
+        return redisTemplate.opsForList().size(generateQueueKey(couponId));
+    }
+
+    public Long findUserIdByIssuedCoupon(Long couponId) {
+        String userId = redisTemplate.opsForList().leftPop(generateQueueKey(couponId));
+        return userId == null ? null : Long.valueOf(userId);
+    }
+
+    public Boolean availableUserIssueQuantity(Long couponId, Long userId) {
+        return Boolean.FALSE.equals(redisTemplate.opsForSet()
+                .isMember(generateKey(couponId), String.valueOf(userId)));
+    }
+
+    public boolean availableTotalIssueQuantity(Long couponId, Integer totalQuantity) {
+        if (totalQuantity == null) {
+            return true;
+        }
+        return Objects.requireNonNull(redisTemplate.opsForSet().size(generateKey(couponId))).intValue() < totalQuantity;
+    }
+
+    private String generateKey(Long couponId) {
+        return "issue:request:couponId:%d".formatted(couponId);
+    }
+
+    private String generateQueueKey(Long couponId) {
+        return "%s:%d".formatted(QUEUE_KEY, couponId);
+    }
+
+    public void issueByScript(Long couponId, Long userId, Integer totalIssueQuantity) {
+        String code = redisTemplate.execute(
+                requestScript(),
+                List.of(generateKey(couponId), generateQueueKey(couponId)),
+                String.valueOf(userId),
+                String.valueOf(totalIssueQuantity),
+                String.valueOf(userId)
+        );
+
+        CouponIssueRequestScriptResult.check(CouponIssueRequestScriptResult.findCode(code));
+    }
+
+    private RedisScript<String> requestScript() {
+        String script = """
+                if redis.call('sismember', KEYS[1], ARGV[1]) == 1 then
+                    return '2'
+                end
+                
+                if redis.call('scard', KEYS[1]) < tonumber(ARGV[2]) then
+                    redis.call('sadd', KEYS[1], ARGV[1])
+                    redis.call('rpush', KEYS[2], ARGV[3])
+                    return '1'
+                end
+                
+                return '3'
+                """;
+        return RedisScript.of(script, String.class);
+    }
+
+    @AllArgsConstructor
+    public enum CouponIssueRequestScriptResult {
+        SUCCESS(1),
+        DUPLICATED_COUPON_ISSUE(2),
+        INVALID_COUPON_ISSUE_QUANTITY(3);
+
+        private final int code;
+
+        public static CouponIssueRequestScriptResult findCode(String code) {
+            int codeValue = Integer.parseInt(code);
+            for (CouponIssueRequestScriptResult result : values()) {
+                if (result.code == codeValue) {
+                    return result;
+                }
+            }
+            throw new IllegalArgumentException("Invalid CouponIssueScriptResult code: %s".formatted(code));
+        }
+
+        public static void check(CouponIssueRequestScriptResult result) {
+            if (result == INVALID_COUPON_ISSUE_QUANTITY) {
+                throw CouponCoreErrorCode.INVALID_COUPON_ISSUE_QUANTITY.build();
+            }
+            if (result == DUPLICATED_COUPON_ISSUE) {
+                throw CouponCoreErrorCode.DUPLICATED_COUPON_ISSUED.build();
+            }
+        }
+    }
+}

--- a/coupon-core/src/main/java/cwchoiit/couponcore/service/CouponService.java
+++ b/coupon-core/src/main/java/cwchoiit/couponcore/service/CouponService.java
@@ -1,15 +1,20 @@
 package cwchoiit.couponcore.service;
 
+import cwchoiit.couponcore.model.Coupon;
 import cwchoiit.couponcore.repository.CouponRepository;
 import cwchoiit.couponcore.service.response.CouponReadResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static cwchoiit.couponcore.exception.CouponCoreErrorCode.COUPON_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CouponService {
 
     private final CouponRepository couponRepository;
@@ -19,5 +24,13 @@ public class CouponService {
         return couponRepository.findById(couponId)
                 .map(CouponReadResponse::of)
                 .orElseThrow(() -> COUPON_NOT_FOUND.build(couponId));
+    }
+
+    public List<Coupon> findAll() {
+        return couponRepository.findAll();
+    }
+
+    public Coupon findById(Long couponId) {
+        return couponRepository.findById(couponId).orElseThrow(() -> COUPON_NOT_FOUND.build(couponId));
     }
 }

--- a/coupon-core/src/test/java/cwchoiit/couponcore/service/CouponIssueRequestServiceTest.java
+++ b/coupon-core/src/test/java/cwchoiit/couponcore/service/CouponIssueRequestServiceTest.java
@@ -1,0 +1,176 @@
+package cwchoiit.couponcore.service;
+
+import cwchoiit.couponcore.EmbeddedRedis;
+import cwchoiit.couponcore.TestConfigurations;
+import cwchoiit.couponcore.exception.CouponCoreException;
+import cwchoiit.couponcore.model.Coupon;
+import cwchoiit.couponcore.model.CouponType;
+import cwchoiit.couponcore.repository.CouponRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.time.LocalDateTime;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Import(EmbeddedRedis.class)
+@DisplayName("Service - CouponIssueRequestService")
+class CouponIssueRequestServiceTest extends TestConfigurations {
+
+    @Autowired
+    RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    CouponIssueRequestService couponIssueRequestService;
+
+    @Autowired
+    CouponRepository couponRepository;
+
+    @BeforeEach
+    public void beforeEach() {
+        redisTemplate.delete(redisTemplate.keys("*"));
+    }
+
+    @Test
+    @DisplayName("쿠폰 발급 요청 - 쿠폰이 존재하지 않는다면 예외가 발생해야 한다.")
+    void request_coupon_not_found() {
+        assertThatThrownBy(() -> couponIssueRequestService.request(1L, 2L))
+                .isInstanceOf(CouponCoreException.class)
+                .hasFieldOrPropertyWithValue("code", "COUPON-C-0004");
+    }
+
+    @Test
+    @DisplayName("쿠폰 발급 요청 기한 검증 - 발급 기한에 해당하지 않으면 예외가 발생해야 한다.")
+    void available_request_date_fail() {
+        Coupon coupon = couponRepository.save(Coupon.builder()
+                .couponType(CouponType.FIRST_COME_FIRST_SERVED)
+                .title("선착순 테스트 쿠폰")
+                .totalQuantity(100)
+                .issuedQuantity(0)
+                .dateIssueStart(LocalDateTime.now().minusDays(2))
+                .dateIssueEnd(LocalDateTime.now().minusDays(1))
+                .build()
+        );
+
+        assertThatThrownBy(() -> couponIssueRequestService.request(coupon.getCouponId(), 2L))
+                .isInstanceOf(CouponCoreException.class)
+                .hasFieldOrPropertyWithValue("code", "COUPON-C-0002");
+    }
+
+    @Test
+    @DisplayName("쿠폰 발급 요청 후 검증 - 쿠폰 발급이 정상적으로 처리됐다면, 해당 유저가 선착순 큐에 저장되어야 한다.")
+    void issued_user_check() {
+        Coupon coupon = couponRepository.save(Coupon.builder()
+                .couponType(CouponType.FIRST_COME_FIRST_SERVED)
+                .title("선착순 테스트 쿠폰")
+                .totalQuantity(100)
+                .issuedQuantity(0)
+                .dateIssueStart(LocalDateTime.now().minusDays(2))
+                .dateIssueEnd(LocalDateTime.now().plusDays(1))
+                .build()
+        );
+
+        couponIssueRequestService.request(coupon.getCouponId(), 2L);
+
+        // 중복 유저는 발급 받을 수 없어야 한다.
+        boolean isOk = couponIssueRequestService.availableUserIssueQuantity(coupon.getCouponId(), 2L);
+        assertThat(isOk).isFalse();
+
+        Boolean isMember = redisTemplate.opsForSet()
+                .isMember("issue:request:couponId:%s".formatted(coupon.getCouponId()), "2");
+        assertThat(isMember).isTrue();
+    }
+
+    @Test
+    @DisplayName("쿠폰 발급 요청 후 검증 - 쿠폰 발급이 정상적으로 처리됐다면, 해당 유저가 발급 큐에 저장되어야 한다.")
+    void issued_user_check_2() {
+        Coupon coupon = couponRepository.save(Coupon.builder()
+                .couponType(CouponType.FIRST_COME_FIRST_SERVED)
+                .title("선착순 테스트 쿠폰")
+                .totalQuantity(100)
+                .issuedQuantity(0)
+                .dateIssueStart(LocalDateTime.now().minusDays(2))
+                .dateIssueEnd(LocalDateTime.now().plusDays(1))
+                .build()
+        );
+
+        couponIssueRequestService.request(coupon.getCouponId(), 2L);
+
+        // 중복 유저는 발급 받을 수 없어야 한다.
+        boolean isOk = couponIssueRequestService.availableUserIssueQuantity(coupon.getCouponId(), 2L);
+        assertThat(isOk).isFalse();
+
+        String userId = redisTemplate.opsForList()
+                .leftPop("issued:queue:couponId:%s".formatted(coupon.getCouponId()));
+        assertThat(userId).isEqualTo("2");
+    }
+
+    @Test
+    @DisplayName("쿠폰 요청 수량 검증 - 발급 가능 수량이 존재하면 쿠폰을 발급받을 수 있다.")
+    void available_request_quantity_success() {
+        boolean isOk = couponIssueRequestService.availableTotalIssueQuantity(1L, 100);
+        assertThat(isOk).isTrue();
+    }
+
+    @Test
+    @DisplayName("쿠폰 요청 수량 검증 - 발급 가능 수량이 없으면 쿠폰을 발급받을 수 없다.")
+    void available_request_quantity_fail() {
+        int totalQuantity = 100;
+
+        Coupon coupon = couponRepository.save(Coupon.builder()
+                        .couponType(CouponType.FIRST_COME_FIRST_SERVED)
+                        .title("선착순 테스트 쿠폰")
+                        .totalQuantity(totalQuantity)
+                        .issuedQuantity(0)
+                        .dateIssueStart(LocalDateTime.now().minusDays(2))
+                        .dateIssueEnd(LocalDateTime.now().plusDays(2))
+                        .build()
+        );
+
+        IntStream.range(0, totalQuantity)
+                .forEach(userId -> couponIssueRequestService.request(coupon.getCouponId(), (long) userId));
+
+        boolean isOk = couponIssueRequestService.availableTotalIssueQuantity(coupon.getCouponId(), totalQuantity);
+        assertThat(isOk).isFalse();
+
+        assertThatThrownBy(() -> couponIssueRequestService.request(coupon.getCouponId(), 200L))
+                .isInstanceOf(CouponCoreException.class)
+                .hasFieldOrPropertyWithValue("code", "COUPON-C-0001");
+    }
+
+    @Test
+    @DisplayName("쿠폰 중복 발급 요청 검증 - 발급된 내역에 유저가 존재하지 않으면 발급받을 수 있다.")
+    void available_user_request_quantity_duplicated_success() {
+        boolean isOk = couponIssueRequestService.availableUserIssueQuantity(2L, 2L);
+        assertThat(isOk).isTrue();
+    }
+
+    @Test
+    @DisplayName("쿠폰 중복 발급 요청 검증 - 발급된 내역에 유저가 존재하면 발급받을 수 없다.")
+    void available_user_request_quantity_duplicated_fail() {
+        Coupon coupon = couponRepository.save(Coupon.builder()
+                .couponType(CouponType.FIRST_COME_FIRST_SERVED)
+                .title("선착순 테스트 쿠폰")
+                .totalQuantity(100)
+                .issuedQuantity(0)
+                .dateIssueStart(LocalDateTime.now().minusDays(2))
+                .dateIssueEnd(LocalDateTime.now().plusDays(2))
+                .build()
+        );
+
+        couponIssueRequestService.request(coupon.getCouponId(), 2L);
+
+        boolean isOk = couponIssueRequestService.availableUserIssueQuantity(coupon.getCouponId(), 2L);
+        assertThat(isOk).isFalse();
+
+        assertThatThrownBy(() -> couponIssueRequestService.request(coupon.getCouponId(), 2L))
+                .isInstanceOf(CouponCoreException.class)
+                .hasFieldOrPropertyWithValue("code", "COUPON-C-0003");
+    }
+}

--- a/coupon-core/src/test/java/cwchoiit/couponcore/service/CouponIssueServiceTest.java
+++ b/coupon-core/src/test/java/cwchoiit/couponcore/service/CouponIssueServiceTest.java
@@ -4,50 +4,101 @@ import cwchoiit.couponcore.EmbeddedRedis;
 import cwchoiit.couponcore.TestConfigurations;
 import cwchoiit.couponcore.exception.CouponCoreException;
 import cwchoiit.couponcore.model.Coupon;
+import cwchoiit.couponcore.model.CouponIssued;
 import cwchoiit.couponcore.model.CouponType;
+import cwchoiit.couponcore.repository.CouponIssuedQueryDslRepository;
+import cwchoiit.couponcore.repository.CouponIssuedRepository;
 import cwchoiit.couponcore.repository.CouponRepository;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.redis.core.RedisTemplate;
 
 import java.time.LocalDateTime;
-import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Import(EmbeddedRedis.class)
 @DisplayName("Service - CouponIssueService")
-class CouponIssueServiceTest extends TestConfigurations {
-
-    @Autowired
-    RedisTemplate<String, String> redisTemplate;
+public class CouponIssueServiceTest extends TestConfigurations {
 
     @Autowired
     CouponIssueService couponIssueService;
 
     @Autowired
+    CouponIssuedRepository couponIssuedRepository;
+
+    @Autowired
     CouponRepository couponRepository;
 
-    @BeforeEach
-    public void beforeEach() {
-        redisTemplate.delete(redisTemplate.keys("*"));
-    }
+    @Autowired
+    CouponIssuedQueryDslRepository couponIssuedQueryDslRepository;
 
     @Test
-    @DisplayName("쿠폰 발급 - 쿠폰이 존재하지 않는다면 예외가 발생해야 한다.")
-    void issue_coupon_not_found() {
-        assertThatThrownBy(() -> couponIssueService.issue(1L, 2L))
+    @DisplayName("기존에 쿠폰을 발급받았다면, 추가적으로 쿠폰을 발급하지 못한다.")
+    void coupon_issued_fail() {
+        CouponIssued couponIssued = CouponIssued.of(1L, 1L);
+        couponIssuedRepository.save(couponIssued);
+
+        assertThatThrownBy(() -> couponIssueService.saveCouponIssued(1L, 1L))
                 .isInstanceOf(CouponCoreException.class)
-                .hasFieldOrPropertyWithValue("code", "COUPON-C-0004");
+                .hasFieldOrPropertyWithValue("code", "COUPON-C-0003");
     }
 
     @Test
-    @DisplayName("쿠폰 발급 기한 검증 - 발급 기한에 해당하지 않으면 예외가 발생해야 한다.")
-    void available_issue_date_fail() {
+    @DisplayName("기존에 쿠폰을 발급받지 않았다면, 쿠폰을 발급받을 수 있다.")
+    void coupon_issued_success() {
+        CouponIssued couponIssued = couponIssueService.saveCouponIssued(1L, 1L);
+        assertThat(couponIssuedRepository.findById(couponIssued.getIssueId())).isNotNull();
+    }
+
+    @Test
+    @DisplayName("쿠폰 발급 성공 케이스")
+    void issue_success() {
+        Coupon coupon = couponRepository.save(Coupon.builder()
+                .couponType(CouponType.FIRST_COME_FIRST_SERVED)
+                .title("선착순 테스트 쿠폰")
+                .totalQuantity(100)
+                .issuedQuantity(0)
+                .dateIssueStart(LocalDateTime.now().minusDays(1))
+                .dateIssueEnd(LocalDateTime.now().plusDays(1))
+                .build()
+        );
+
+        couponIssueService.issue(coupon.getCouponId(), 1L);
+
+        Coupon savedCoupon = couponRepository.findById(coupon.getCouponId()).get();
+        assertThat(savedCoupon).isNotNull();
+        assertThat(savedCoupon.getIssuedQuantity()).isEqualTo(1);
+
+        CouponIssued couponIssued = couponIssuedQueryDslRepository.findCouponIssue(coupon.getCouponId(), 1L);
+        assertThat(couponIssued).isNotNull();
+        assertThat(couponIssued.getUserId()).isEqualTo(1L);
+        assertThat(couponIssued.getDateUsed()).isNull();
+    }
+
+    @Test
+    @DisplayName("쿠폰 발급 실패 케이스 - 발급 수량 문제")
+    void issue_fail_quantity() {
+        Coupon coupon = couponRepository.save(Coupon.builder()
+                .couponType(CouponType.FIRST_COME_FIRST_SERVED)
+                .title("선착순 테스트 쿠폰")
+                .totalQuantity(100)
+                .issuedQuantity(100)
+                .dateIssueStart(LocalDateTime.now().minusDays(1))
+                .dateIssueEnd(LocalDateTime.now().plusDays(1))
+                .build()
+        );
+
+        assertThatThrownBy(() -> couponIssueService.issue(coupon.getCouponId(), 1L))
+                .isInstanceOf(CouponCoreException.class)
+                .hasFieldOrPropertyWithValue("code", "COUPON-C-0001");
+    }
+
+    @Test
+    @DisplayName("쿠폰 발급 실패 케이스 - 발급 기한 문제")
+    void issue_fail_expired() {
         Coupon coupon = couponRepository.save(Coupon.builder()
                 .couponType(CouponType.FIRST_COME_FIRST_SERVED)
                 .title("선착순 테스트 쿠폰")
@@ -58,102 +109,14 @@ class CouponIssueServiceTest extends TestConfigurations {
                 .build()
         );
 
-        assertThatThrownBy(() -> couponIssueService.issue(coupon.getCouponId(), 2L))
+        assertThatThrownBy(() -> couponIssueService.issue(coupon.getCouponId(), 1L))
                 .isInstanceOf(CouponCoreException.class)
                 .hasFieldOrPropertyWithValue("code", "COUPON-C-0002");
     }
 
     @Test
-    @DisplayName("쿠폰 발급 후 검증 - 쿠폰 발급이 정상적으로 처리됐다면, 해당 유저가 선착순 큐에 저장되어야 한다.")
-    void issued_user_check() {
-        Coupon coupon = couponRepository.save(Coupon.builder()
-                .couponType(CouponType.FIRST_COME_FIRST_SERVED)
-                .title("선착순 테스트 쿠폰")
-                .totalQuantity(100)
-                .issuedQuantity(0)
-                .dateIssueStart(LocalDateTime.now().minusDays(2))
-                .dateIssueEnd(LocalDateTime.now().plusDays(1))
-                .build()
-        );
-
-        couponIssueService.issue(coupon.getCouponId(), 2L);
-
-        // 중복 유저는 발급 받을 수 없어야 한다.
-        boolean isOk = couponIssueService.availableUserIssueQuantity(coupon.getCouponId(), 2L);
-        assertThat(isOk).isFalse();
-
-        Boolean isMember = redisTemplate.opsForSet()
-                .isMember("issue:request:couponId:%s".formatted(coupon.getCouponId()), "2");
-        assertThat(isMember).isTrue();
-    }
-
-    @Test
-    @DisplayName("쿠폰 발급 후 검증 - 쿠폰 발급이 정상적으로 처리됐다면, 해당 유저가 발급 큐에 저장되어야 한다.")
-    void issued_user_check_2() {
-        Coupon coupon = couponRepository.save(Coupon.builder()
-                .couponType(CouponType.FIRST_COME_FIRST_SERVED)
-                .title("선착순 테스트 쿠폰")
-                .totalQuantity(100)
-                .issuedQuantity(0)
-                .dateIssueStart(LocalDateTime.now().minusDays(2))
-                .dateIssueEnd(LocalDateTime.now().plusDays(1))
-                .build()
-        );
-
-        couponIssueService.issue(coupon.getCouponId(), 2L);
-
-        // 중복 유저는 발급 받을 수 없어야 한다.
-        boolean isOk = couponIssueService.availableUserIssueQuantity(coupon.getCouponId(), 2L);
-        assertThat(isOk).isFalse();
-
-        String userId = redisTemplate.opsForList()
-                .leftPop("issued:queue:couponId:%s".formatted(coupon.getCouponId()));
-        assertThat(userId).isEqualTo("2");
-    }
-
-    @Test
-    @DisplayName("쿠폰 수량 검증 - 발급 가능 수량이 존재하면 쿠폰을 발급받을 수 있다.")
-    void available_issue_quantity_success() {
-        boolean isOk = couponIssueService.availableTotalIssueQuantity(1L, 100);
-        assertThat(isOk).isTrue();
-    }
-
-    @Test
-    @DisplayName("쿠폰 수량 검증 - 발급 가능 수량이 없으면 쿠폰을 발급받을 수 없다.")
-    void available_issue_quantity_fail() {
-        int totalQuantity = 100;
-
-        Coupon coupon = couponRepository.save(Coupon.builder()
-                        .couponType(CouponType.FIRST_COME_FIRST_SERVED)
-                        .title("선착순 테스트 쿠폰")
-                        .totalQuantity(totalQuantity)
-                        .issuedQuantity(0)
-                        .dateIssueStart(LocalDateTime.now().minusDays(2))
-                        .dateIssueEnd(LocalDateTime.now().plusDays(2))
-                        .build()
-        );
-
-        IntStream.range(0, totalQuantity)
-                .forEach(userId -> couponIssueService.issue(coupon.getCouponId(), (long) userId));
-
-        boolean isOk = couponIssueService.availableTotalIssueQuantity(coupon.getCouponId(), totalQuantity);
-        assertThat(isOk).isFalse();
-
-        assertThatThrownBy(() -> couponIssueService.issue(coupon.getCouponId(), 200L))
-                .isInstanceOf(CouponCoreException.class)
-                .hasFieldOrPropertyWithValue("code", "COUPON-C-0001");
-    }
-
-    @Test
-    @DisplayName("쿠폰 중복 발급 검증 - 발급된 내역에 유저가 존재하지 않으면 발급받을 수 있다.")
-    void available_user_issue_quantity_duplicated_success() {
-        boolean isOk = couponIssueService.availableUserIssueQuantity(2L, 2L);
-        assertThat(isOk).isTrue();
-    }
-
-    @Test
-    @DisplayName("쿠폰 중복 발급 검증 - 발급된 내역에 유저가 존재하면 발급받을 수 없다.")
-    void available_user_issue_quantity_duplicated_fail() {
+    @DisplayName("쿠폰 발급 실패 케이스 - 중복 발급 문제")
+    void issue_fail_duplicated() {
         Coupon coupon = couponRepository.save(Coupon.builder()
                 .couponType(CouponType.FIRST_COME_FIRST_SERVED)
                 .title("선착순 테스트 쿠폰")
@@ -164,13 +127,23 @@ class CouponIssueServiceTest extends TestConfigurations {
                 .build()
         );
 
-        couponIssueService.issue(coupon.getCouponId(), 2L);
+        couponIssueService.issue(coupon.getCouponId(), 1L);
 
-        boolean isOk = couponIssueService.availableUserIssueQuantity(coupon.getCouponId(), 2L);
-        assertThat(isOk).isFalse();
+        CouponIssued issuedCoupon = couponIssuedQueryDslRepository.findCouponIssue(coupon.getCouponId(), 1L);
+        assertThat(issuedCoupon).isNotNull();
+        assertThat(issuedCoupon.getUserId()).isEqualTo(1L);
+        assertThat(issuedCoupon.getCouponId()).isEqualTo(coupon.getCouponId());
 
-        assertThatThrownBy(() -> couponIssueService.issue(coupon.getCouponId(), 2L))
+        assertThatThrownBy(() -> couponIssueService.issue(coupon.getCouponId(), 1L))
                 .isInstanceOf(CouponCoreException.class)
                 .hasFieldOrPropertyWithValue("code", "COUPON-C-0003");
+    }
+
+    @Test
+    @DisplayName("없는 쿠폰을 발급하려고 하면 예외 발생")
+    void coupon_not_found() {
+        assertThatThrownBy(() -> couponIssueService.issue(1L, 1L))
+                .isInstanceOf(CouponCoreException.class)
+                .hasFieldOrPropertyWithValue("code", "COUPON-C-0004");
     }
 }


### PR DESCRIPTION
- 사용자들의 쿠폰 발급 요청은 레디스로 받아 레디스 큐에 적재
- 실제 쿠폰 발급 데이터를 저장할 MySQL에서는 Consumer 모듈을 만들어 주기적으로 리스닝
- 사용자들의 발급 요청을 처리하는 모듈 + 발급 요청에 성공한 사용자들의 데이터를 저장하는 모듈
