### PR TITLE
로컬 캐시 적용 및 코드 리팩토링

### DIFF
--- a/coupon-api/src/main/java/cwchoiit/couponapi/controller/response/ApiResponse.java
+++ b/coupon-api/src/main/java/cwchoiit/couponapi/controller/response/ApiResponse.java
@@ -58,16 +58,16 @@ public class ApiResponse <T> {
 
     private void generateHttpStatus(String errorCode) {
         if ("COUPON-C-0001".equals(errorCode)) {
-            this.errorStatus = HttpStatus.NO_CONTENT;
+            this.errorStatus = HttpStatus.BAD_REQUEST;
         }
         if ("COUPON-C-0002".equals(errorCode)) {
-            this.errorStatus = HttpStatus.NO_CONTENT;
+            this.errorStatus = HttpStatus.BAD_REQUEST;
         }
         if ("COUPON-C-0003".equals(errorCode)) {
-            this.errorStatus = HttpStatus.NO_CONTENT;
+            this.errorStatus = HttpStatus.BAD_REQUEST;
         }
         if ("COUPON-C-0004".equals(errorCode)) {
-            this.errorStatus = HttpStatus.NO_CONTENT;
+            this.errorStatus = HttpStatus.NOT_FOUND;
         }
     }
 }

--- a/coupon-core/build.gradle
+++ b/coupon-core/build.gradle
@@ -4,5 +4,6 @@ dependencies {
     implementation 'org.redisson:redisson-spring-boot-starter:3.37.0'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.github.ben-manes.caffeine:caffeine' // Redis에 캐싱 데이터 조회가 아닌 로컬 메모리에 올려두기 위한 의존성
     testImplementation 'com.github.codemonstur:embedded-redis:1.4.3'
 }

--- a/coupon-core/src/main/java/cwchoiit/couponcore/CouponCoreConfiguration.java
+++ b/coupon-core/src/main/java/cwchoiit/couponcore/CouponCoreConfiguration.java
@@ -3,11 +3,13 @@ package cwchoiit.couponcore;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @ComponentScan
 @EnableCaching
 @EnableJpaAuditing
 @EnableAutoConfiguration
+@EnableAspectJAutoProxy(exposeProxy = true)
 public class CouponCoreConfiguration {
 }

--- a/coupon-core/src/main/java/cwchoiit/couponcore/component/CouponEventListener.java
+++ b/coupon-core/src/main/java/cwchoiit/couponcore/component/CouponEventListener.java
@@ -1,0 +1,25 @@
+package cwchoiit.couponcore.component;
+
+import cwchoiit.couponcore.model.CouponIssueCompleteEvent;
+import cwchoiit.couponcore.service.CouponService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CouponEventListener {
+
+    private final CouponService couponService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void issueCompleted(CouponIssueCompleteEvent event) {
+        log.info("[issueCompleted] Coupon issue completed. cache refresh start coupon ID = {}", event.couponId());
+        couponService.putCouponCache(event.couponId());
+        couponService.putCouponLocalCache(event.couponId());
+        log.info("[issueCompleted] Coupon issue completed. cache refresh end coupon ID = {}", event.couponId());
+    }
+}

--- a/coupon-core/src/main/java/cwchoiit/couponcore/config/CacheConfig.java
+++ b/coupon-core/src/main/java/cwchoiit/couponcore/config/CacheConfig.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -34,6 +35,7 @@ public class CacheConfig {
     }
 
     @Bean
+    @Primary
     public CacheManager cacheManager() {
         ObjectMapper redisMapper = new ObjectMapper()
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)

--- a/coupon-core/src/main/java/cwchoiit/couponcore/config/LocalCacheConfig.java
+++ b/coupon-core/src/main/java/cwchoiit/couponcore/config/LocalCacheConfig.java
@@ -1,0 +1,23 @@
+package cwchoiit.couponcore.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+@Configuration
+public class LocalCacheConfig {
+
+    @Bean
+    public CacheManager localCacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+        cacheManager.setCaffeine(Caffeine.newBuilder()
+                .expireAfterWrite(Duration.ofSeconds(10))
+                .maximumSize(1000)
+        );
+        return cacheManager;
+    }
+}

--- a/coupon-core/src/main/java/cwchoiit/couponcore/model/Coupon.java
+++ b/coupon-core/src/main/java/cwchoiit/couponcore/model/Coupon.java
@@ -66,4 +66,9 @@ public class Coupon extends BaseEntity {
         }
         issuedQuantity++;
     }
+
+    public boolean isIssueCompleted() {
+        LocalDateTime now = LocalDateTime.now();
+        return dateIssueEnd.isBefore(now) || !availableIssueQuantity();
+    }
 }

--- a/coupon-core/src/main/java/cwchoiit/couponcore/model/CouponIssueCompleteEvent.java
+++ b/coupon-core/src/main/java/cwchoiit/couponcore/model/CouponIssueCompleteEvent.java
@@ -1,0 +1,4 @@
+package cwchoiit.couponcore.model;
+
+public record CouponIssueCompleteEvent(Long couponId) {
+}

--- a/coupon-core/src/main/java/cwchoiit/couponcore/service/CouponIssueRequestService.java
+++ b/coupon-core/src/main/java/cwchoiit/couponcore/service/CouponIssueRequestService.java
@@ -28,7 +28,7 @@ public class CouponIssueRequestService {
     private final DistributeLockExecutor distributeLockExecutor;
 
     public void request(Long couponId, Long userId) {
-        CouponReadResponse couponReadResponse = couponService.findCoupon(couponId);
+        CouponReadResponse couponReadResponse = couponService.findCouponByLocalCache(couponId);
         Coupon coupon = Coupon.builder()
                 .couponId(couponReadResponse.getCouponId())
                 .title(couponReadResponse.getTitle())
@@ -38,6 +38,10 @@ public class CouponIssueRequestService {
                 .dateIssueStart(couponReadResponse.getDateIssueStart())
                 .dateIssueEnd(couponReadResponse.getDateIssueEnd())
                 .build();
+
+        if (!coupon.availableIssueQuantity()) {
+            throw INVALID_COUPON_ISSUE_QUANTITY.build(coupon.getIssuedQuantity(), coupon.getTotalQuantity());
+        }
 
         if (!coupon.availableIssueDate()) {
             throw INVALID_COUPON_ISSUE_DATE.build(

--- a/coupon-core/src/main/java/cwchoiit/couponcore/service/response/CouponReadResponse.java
+++ b/coupon-core/src/main/java/cwchoiit/couponcore/service/response/CouponReadResponse.java
@@ -16,6 +16,7 @@ public class CouponReadResponse {
     private CouponType couponType;
     private Integer totalQuantity;
     private int issuedQuantity;
+    private boolean availableIssueQuantity;
     private LocalDateTime dateIssueStart;
     private LocalDateTime dateIssueEnd;
 
@@ -26,6 +27,7 @@ public class CouponReadResponse {
         response.couponType = coupon.getCouponType();
         response.totalQuantity = coupon.getTotalQuantity();
         response.issuedQuantity = coupon.getIssuedQuantity();
+        response.availableIssueQuantity = coupon.availableIssueQuantity();
         response.dateIssueStart = coupon.getDateIssueStart();
         response.dateIssueEnd = coupon.getDateIssueEnd();
         return response;

--- a/coupon-core/src/test/java/cwchoiit/couponcore/model/CouponTest.java
+++ b/coupon-core/src/test/java/cwchoiit/couponcore/model/CouponTest.java
@@ -1,11 +1,13 @@
 package cwchoiit.couponcore.model;
 
 import cwchoiit.couponcore.exception.CouponCoreException;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -127,5 +129,44 @@ class CouponTest {
 
         assertThatThrownBy(coupon::issue).isInstanceOf(RuntimeException.class)
                 .hasFieldOrPropertyWithValue("code", "COUPON-C-0001");
+    }
+
+    @Test
+    @DisplayName("쿠폰 객체의 isIssueCompleted() 메서드 동작 확인 - 1")
+    void is_issue_completed() {
+        Coupon coupon = Coupon.builder()
+                .totalQuantity(100)
+                .issuedQuantity(0)
+                .dateIssueStart(LocalDateTime.now().minusDays(2))
+                .dateIssueEnd(LocalDateTime.now().minusDays(1))
+                .build();
+
+        assertThat(coupon.isIssueCompleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("쿠폰 객체의 isIssueCompleted() 메서드 동작 확인 - 2")
+    void is_issue_completed_2() {
+        Coupon coupon = Coupon.builder()
+                .totalQuantity(100)
+                .issuedQuantity(100)
+                .dateIssueStart(LocalDateTime.now().minusDays(2))
+                .dateIssueEnd(LocalDateTime.now().plusDays(1))
+                .build();
+
+        assertThat(coupon.isIssueCompleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("쿠폰 객체의 isIssueCompleted() 메서드 동작 확인 - 3")
+    void is_issue_completed_3() {
+        Coupon coupon = Coupon.builder()
+                .totalQuantity(100)
+                .issuedQuantity(0)
+                .dateIssueStart(LocalDateTime.now().minusDays(2))
+                .dateIssueEnd(LocalDateTime.now().plusDays(1))
+                .build();
+
+        assertThat(coupon.isIssueCompleted()).isFalse();
     }
 }


### PR DESCRIPTION
- 현재 상태는 쿠폰 엔티티를 레디스에 캐싱하고 있으나, 로컬 메모리에 캐시해두면 레디스와의 I/O 작업을 처리하지 않아도 되니 성능 향상 기대
- 쿠폰 발급이 다 끝나도 레디스를 찔러 여부에 대한 처리를 하는 것을 쿠폰 발급이 끝나면 이벤트를 퍼블리싱하고 이벤트를 리슨하고 있는 리스너에서 쿠폰 엔티티 캐시를 업데이트한다. 그럼 최초에 쿠폰 엔티티를 가져오는 부분에서 쿠폰 발급 여부를 체크해서 쿠폰 발급이 끝났다면 아예 레디스를 찌르지도 않게 하여 성능 향상 기대
